### PR TITLE
Implement automatic notification tap handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.0-dev.5
+
+- Implement automatic notification tap handling in plugin
+- Remove requirement for custom MainActivity setup
+- Simplify integration process
+
 ## 1.0.0-dev.4
 
 - Fix parameter signature mismatch in updateMetadata method

--- a/README.md
+++ b/README.md
@@ -152,35 +152,6 @@ Add the following to `android/app/src/main/AndroidManifest.xml`:
 </application>
 ```
 
-#### 4. MainActivity Setup
-
-Update `android/app/src/main/kotlin/.../MainActivity.kt`:
-
-```kotlin
-import android.content.Intent
-import io.flutter.embedding.android.FlutterActivity
-import io.pnta.pnta_flutter.NotificationTapHandler
-
-class MainActivity: FlutterActivity() {
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-        val extras = intent.extras
-        if (extras != null && !extras.isEmpty) {
-            val payload = mutableMapOf<String, Any>()
-            for (key in extras.keySet()) {
-                val value = extras.get(key)
-                when (value) {
-                    is String, is Int, is Boolean, is Double, is Float, is Long -> payload[key] = value
-                    else -> payload[key] = value.toString()
-                }
-            }
-            if (payload.isNotEmpty()) {
-                NotificationTapHandler.sendTapPayload(payload)
-            }
-        }
-    }
-}
-```
 
 ## Quick Start Guide
 

--- a/example/android/app/src/main/kotlin/io/pnta/pnta_flutter_example/MainActivity.kt
+++ b/example/android/app/src/main/kotlin/io/pnta/pnta_flutter_example/MainActivity.kt
@@ -1,26 +1,5 @@
 package io.pnta.pnta_flutter_example
 
-import android.content.Intent
-import android.os.Bundle
 import io.flutter.embedding.android.FlutterActivity
-import io.pnta.pnta_flutter.NotificationTapHandler
 
-class MainActivity: FlutterActivity() {
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-        val extras = intent.extras
-        if (extras != null && !extras.isEmpty) {
-            val payload = mutableMapOf<String, Any>()
-            for (key in extras.keySet()) {
-                val value = extras.get(key)
-                when (value) {
-                    is String, is Int, is Boolean, is Double, is Float, is Long -> payload[key] = value
-                    else -> payload[key] = value.toString()
-                }
-            }
-            if (payload.isNotEmpty()) {
-                NotificationTapHandler.sendTapPayload(payload)
-            }
-        }
-    }
-}
+class MainActivity: FlutterActivity() {}

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,3 +1,3 @@
 /// PNTA Flutter SDK version
 /// This should match the version in pubspec.yaml
-const String kPntaSdkVersion = '1.0.0-dev.4';
+const String kPntaSdkVersion = '1.0.0-dev.5';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pnta_flutter
 description: "Official PNTA Flutter plugin to make push notifications suck less."
-version: 1.0.0-dev.4
+version: 1.0.0-dev.5
 homepage: https://pnta.io
 repository: https://github.com/smth-digital/pnta-flutter-plugin
 


### PR DESCRIPTION
## Summary
- Moved notification tap handling from MainActivity to the plugin itself
- Eliminated the need for custom MainActivity setup
- Simplified Android integration by removing boilerplate code

## Changes
- Added `NewIntentListener` interface to `PntaFlutterPlugin` 
- Implemented automatic intent handling in the plugin
- Updated example MainActivity to basic `FlutterActivity` extension
- Removed MainActivity setup section from README
- Bumped version to 1.0.0-dev.5