### PR TITLE
Fix registration lifecycle and simplify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,14 @@ For apps that need to ask for permission at a specific time (e.g., after user on
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Initialize without registering device
+  // Initialize without registering device, but include metadata for later use
   await PntaFlutter.initialize(
     'prj_XXXXXXXXX',
     registerDevice: false,  // Skip device registration
+    metadata: {
+      'user_id': '123',
+      'user_email': 'user@example.com',
+    },
   );
 
   runApp(MyApp());
@@ -174,15 +178,10 @@ void main() async {
 
 // Later in your app, when ready to register:
 Future<void> setupNotifications() async {
-  await PntaFlutter.registerDevice(
-    metadata: {
-      'user_id': '123',
-      'user_email': 'user@example.com',
-    },
-  );
+  await PntaFlutter.registerDevice();
 
   // Optional: Get the device token if you need it for your backend
-  // final deviceToken = await PntaFlutter.registerDevice(...);
+  // final deviceToken = await PntaFlutter.registerDevice();
   // if (deviceToken != null) {
   //   print('Device registered successfully!');
   // } else {
@@ -243,11 +242,9 @@ Main initialization method that handles everything for most apps:
 
 Returns `Future<String?>` - the device token if device was registered, null otherwise.
 
-#### `PntaFlutter.registerDevice({Map<String, dynamic>? metadata})`
+#### `PntaFlutter.registerDevice()`
 
-For delayed registration scenarios. Requests notification permission and registers device. Must be called after `initialize()` with `registerDevice: false`.
-
--   `metadata`: Optional device metadata to include during registration
+For delayed registration scenarios. Requests notification permission and registers device using metadata from `initialize()`. Must be called after `initialize()` with `registerDevice: false`.
 
 Returns `Future<String?>` - the device token if permission was granted and device registered successfully, null otherwise. **Note: You can ignore the return value if you don't need the token.**
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ void main() async {
   );
 
   // Optional: Get the device token if you need it for your backend
-  // final deviceToken = await PntaFlutter.initialize(...);
-  // if (deviceToken != null) {
-  //   print('Device token: $deviceToken');
-  // }
+  final deviceToken = PntaFlutter.deviceToken;
+  if (deviceToken != null) {
+    print('Device token: $deviceToken');
+  }
 
   runApp(MyApp());
 }
@@ -181,12 +181,12 @@ Future<void> setupNotifications() async {
   await PntaFlutter.registerDevice();
 
   // Optional: Get the device token if you need it for your backend
-  // final deviceToken = await PntaFlutter.registerDevice();
-  // if (deviceToken != null) {
-  //   print('Device registered successfully!');
-  // } else {
-  //   print('Registration failed');
-  // }
+  final deviceToken = PntaFlutter.deviceToken;
+  if (deviceToken != null) {
+    print('Device registered successfully! Token: $deviceToken');
+  } else {
+    print('Registration failed or not completed yet');
+  }
 }
 ```
 
@@ -240,13 +240,13 @@ Main initialization method that handles everything for most apps:
 -   `autoHandleLinks`: Automatically handle `link_to` URLs when notifications are tapped (default: `false`)
 -   `showSystemUI`: Show system notification banner/sound when app is in foreground (default: `false`)
 
-Returns `Future<String?>` - the device token if device was registered, null otherwise.
+Returns `Future<void>`. Use `PntaFlutter.deviceToken` getter to access the device token after successful registration.
 
 #### `PntaFlutter.registerDevice()`
 
 For delayed registration scenarios. Requests notification permission and registers device using metadata from `initialize()`. Must be called after `initialize()` with `registerDevice: false`.
 
-Returns `Future<String?>` - the device token if permission was granted and device registered successfully, null otherwise. **Note: You can ignore the return value if you don't need the token.**
+Returns `Future<void>`. Use `PntaFlutter.deviceToken` getter to access the device token after successful registration.
 
 #### `PntaFlutter.updateMetadata(Map<String, dynamic> metadata)`
 
@@ -306,7 +306,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // One-line setup - handles permission, registration, and configuration
-  final deviceToken = await PntaFlutter.initialize(
+  await PntaFlutter.initialize(
     'prj_XXXXXXXXX',        // Your project ID from app.pnta.io
     metadata: {
       'user_id': '123',
@@ -314,8 +314,10 @@ void main() async {
     },
   );
 
+  // Optional: Get the device token if you need it for your backend
+  final deviceToken = PntaFlutter.deviceToken;
   if (deviceToken != null) {
-    print('Device registered successfully!');
+    print('Device registered successfully! Token: $deviceToken');
   }
 
   runApp(MyApp());

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/PermissionHandler.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/PermissionHandler.kt
@@ -29,6 +29,20 @@ object PermissionHandler {
         }
     }
 
+    fun checkNotificationPermission(activity: Activity?, result: Result) {
+        if (Build.VERSION.SDK_INT >= 33) {
+            if (activity == null) {
+                result.error("NO_ACTIVITY", "Activity is null", null)
+                return
+            }
+            val granted = ContextCompat.checkSelfPermission(activity, android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+            result.success(granted)
+        } else {
+            // Permission is automatically granted on older versions
+            result.success(true)
+        }
+    }
+
     fun onRequestPermissionsResult(requestCode: Int, permissions: Array<out String>, grantResults: IntArray): Boolean {
         if (requestCode == REQUEST_CODE) {
             permissionResult?.success(grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED)

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
@@ -56,6 +56,8 @@ class PntaFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, Plugin
   override fun onMethodCall(call: MethodCall, result: Result) {
     if (call.method == "requestNotificationPermission") {
       PermissionHandler.requestNotificationPermission(activity, result)
+    } else if (call.method == "checkNotificationPermission") {
+      PermissionHandler.checkNotificationPermission(activity, result)
     } else if (call.method == "getDeviceToken") {
       TokenHandler.getDeviceToken(activity, result)
     } else if (call.method == "identify") {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,7 +50,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Future<void> _initPnta() async {
-    final token = await PntaFlutter.initialize(
+    await PntaFlutter.initialize(
       'prj_k3e0Givq',
       metadata: {
         'user_id': '123',
@@ -60,7 +60,7 @@ class _HomeScreenState extends State<HomeScreen> {
       autoHandleLinks: false, // We'll handle links manually for demo
     );
     setState(() {
-      _deviceToken = token;
+      _deviceToken = PntaFlutter.deviceToken;
       _loading = false;
     });
   }

--- a/ios/Classes/PermissionHandler.swift
+++ b/ios/Classes/PermissionHandler.swift
@@ -15,4 +15,18 @@ class PermissionHandler {
             result(true)
         }
     }
+    
+    static func checkNotificationPermission(result: @escaping FlutterResult) {
+        if #available(iOS 10.0, *) {
+            UNUserNotificationCenter.current().getNotificationSettings { settings in
+                DispatchQueue.main.async {
+                    let granted = settings.authorizationStatus == .authorized
+                    result(granted)
+                }
+            }
+        } else {
+            // For iOS versions below 10, permissions are granted at app install time
+            result(true)
+        }
+    }
 } 

--- a/ios/Classes/PntaFlutterPlugin.swift
+++ b/ios/Classes/PntaFlutterPlugin.swift
@@ -17,6 +17,8 @@ public class PntaFlutterPlugin: NSObject, FlutterPlugin, UIApplicationDelegate {
     switch call.method {
     case "requestNotificationPermission":
       PermissionHandler.requestNotificationPermission(result: result)
+    case "checkNotificationPermission":
+      PermissionHandler.checkNotificationPermission(result: result)
     case "getDeviceToken":
       TokenHandler.getDeviceToken(result: result)
     case "identify":

--- a/lib/pnta_flutter.dart
+++ b/lib/pnta_flutter.dart
@@ -26,7 +26,7 @@ class PntaFlutter {
 
   // Setup
   /// Main initialization - handles everything for most apps
-  static Future<String?> initialize(
+  static Future<void> initialize(
     String projectId, {
     Map<String, dynamic>? metadata,
     bool registerDevice = true,
@@ -35,13 +35,13 @@ class PntaFlutter {
   }) async {
     if (_config != null) {
       debugPrint('PNTA: Already initialized.');
-      return _deviceToken;
+      return;
     }
     try {
       // Validate project ID
       if (!projectId.startsWith('prj_')) {
         debugPrint('PNTA: Invalid project ID. Must start with "prj_".');
-        return null;
+        return;
       }
       _config = _PntaFlutterConfig(
         projectId: projectId,
@@ -59,27 +59,24 @@ class PntaFlutter {
       
       if (permissionsGranted) {
         // Always register if permissions available, regardless of registerDevice flag
-        return await _performRegistration(metadata: metadata, skipPrompt: true);
+        await _performRegistration(metadata: metadata, skipPrompt: true);
       } else if (registerDevice) {
         // Only prompt for permissions if registerDevice: true
-        return await _performRegistration(metadata: metadata);
+        await _performRegistration(metadata: metadata);
       }
-      
-      return null; // No permissions, no prompt requested
     } catch (e, st) {
       debugPrint('PNTA: Initialization error: $e\n$st');
-      return null;
     }
   }
 
   // Registration
   /// For delayed registration scenarios - prompts for permissions and registers if granted
-  static Future<String?> registerDevice() async {
+  static Future<void> registerDevice() async {
     if (_config == null) {
       debugPrint('PNTA: Must call initialize() before registering device.');
-      return null;
+      return;
     }
-    return await _performRegistration(metadata: _config!.metadata);
+    await _performRegistration(metadata: _config!.metadata);
   }
 
   /// Update device metadata
@@ -125,7 +122,7 @@ class PntaFlutter {
   static String? get deviceToken => _deviceToken;
 
   // Private
-  static Future<String?> _performRegistration({
+  static Future<void> _performRegistration({
     Map<String, dynamic>? metadata,
     bool skipPrompt = false,
   }) async {
@@ -136,7 +133,7 @@ class PntaFlutter {
       
       if (!granted) {
         debugPrint('PNTA: Notification permission denied.');
-        return null;
+        return;
       }
 
       // Pure device registration with SDK version
@@ -149,11 +146,8 @@ class PntaFlutter {
             .updateMetadata(_config!.projectId, metadata);
         _config!.metadata = metadata;
       }
-
-      return _deviceToken;
     } catch (e, st) {
       debugPrint('PNTA: Registration error: $e\n$st');
-      return null;
     }
   }
 }

--- a/lib/pnta_flutter.dart
+++ b/lib/pnta_flutter.dart
@@ -130,12 +130,9 @@ class PntaFlutter {
     bool skipPrompt = false,
   }) async {
     try {
-      bool granted;
-      if (skipPrompt) {
-        granted = await PntaFlutterPlatform.instance.checkNotificationPermission();
-      } else {
-        granted = await PntaFlutterPlatform.instance.requestNotificationPermission();
-      }
+      final granted = skipPrompt
+        ? await PntaFlutterPlatform.instance.checkNotificationPermission()
+        : await PntaFlutterPlatform.instance.requestNotificationPermission();
       
       if (!granted) {
         debugPrint('PNTA: Notification permission denied.');

--- a/lib/pnta_flutter_method_channel.dart
+++ b/lib/pnta_flutter_method_channel.dart
@@ -26,6 +26,13 @@ class MethodChannelPntaFlutter extends PntaFlutterPlatform {
   }
 
   @override
+  Future<bool> checkNotificationPermission() async {
+    final result =
+        await methodChannel.invokeMethod<bool>('checkNotificationPermission');
+    return result ?? false;
+  }
+
+  @override
   Future<String?> getDeviceToken() async {
     final token = await methodChannel.invokeMethod<String>('getDeviceToken');
     return token;

--- a/lib/pnta_flutter_platform_interface.dart
+++ b/lib/pnta_flutter_platform_interface.dart
@@ -28,6 +28,11 @@ abstract class PntaFlutterPlatform extends PlatformInterface {
         'requestNotificationPermission() has not been implemented.');
   }
 
+  Future<bool> checkNotificationPermission() {
+    throw UnimplementedError(
+        'checkNotificationPermission() has not been implemented.');
+  }
+
   Future<String?> getDeviceToken() {
     throw UnimplementedError('getDeviceToken() has not been implemented.');
   }


### PR DESCRIPTION
  Fix registration lifecycle for delayed registration scenarios and simplify API by using getter pattern for device token access.

  - Add permission checking without prompting for consistent registration
  - Change initialize() and registerDevice() to return Future<void>
  - Use PntaFlutter.deviceToken getter to access token
  - Remove metadata parameter from registerDevice()
  - Update documentation and examples