### PR TITLE
WIP: Remove AGP version constraints for broader compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,69 +1,38 @@
 group = "io.pnta.pnta_flutter"
-version = "1.0-SNAPSHOT"
-
-buildscript {
-    ext.kotlin_version = "1.8.22"
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.2.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
-        classpath("com.google.gms:google-services:4.4.1")
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
+version = "1.0.0"
 
 apply plugin: "com.android.library"
 apply plugin: "kotlin-android"
 
 android {
-    namespace = "io.pnta.pnta_flutter"
-
-    compileSdk = 35
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
+  
+    compileSdkVersion 35
+    
+    if (project.android.hasProperty("namespace")) {
+        namespace = "io.pnta.pnta_flutter"
     }
 
     sourceSets {
         main.java.srcDirs += "src/main/kotlin"
-        test.java.srcDirs += "src/test/kotlin"
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 
     defaultConfig {
-        minSdk = 21
+        minSdkVersion 21
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    dependencies {
-        testImplementation("org.jetbrains.kotlin:kotlin-test")
-        testImplementation("org.mockito:mockito-core:5.0.0")
-        implementation 'com.google.firebase:firebase-messaging:23.4.1'
-        implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    lintOptions {
+        disable 'InvalidPackage'
     }
+}
 
-    testOptions {
-        unitTests.all {
-            useJUnitPlatform()
-
-            testLogging {
-               events "passed", "skipped", "failed", "standardOut", "standardError"
-               outputs.upToDateWhen {false}
-               showStandardStreams = true
-            }
-        }
-    }
+dependencies {
+    implementation 'com.google.firebase:firebase-messaging:23.4.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+    testImplementation 'org.jetbrains.kotlin:kotlin-test'
+    testImplementation 'org.mockito:mockito-core:5.0.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ apply plugin: "kotlin-android"
 
 android {
   
-    compileSdkVersion 35
+    compileSdkVersion 34
     
     if (project.android.hasProperty("namespace")) {
         namespace = "io.pnta.pnta_flutter"

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/ForegroundNotificationHandler.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/ForegroundNotificationHandler.kt
@@ -41,12 +41,27 @@ object ForegroundNotificationHandler : EventChannel.StreamHandler {
             val channel = NotificationChannel(CHANNEL_ID, "General Notifications", NotificationManager.IMPORTANCE_DEFAULT)
             notificationManager.createNotificationChannel(channel)
         }
+        
+        // Create intent for tap handling
+        val intent = Intent().apply {
+            setClassName(context.packageName, "${context.packageName}.MainActivity")
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            data.forEach { (key, value) -> putExtra(key, value.toString()) }
+        }
+        
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            System.currentTimeMillis().toInt(),
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        
         val builder = NotificationCompat.Builder(context, CHANNEL_ID)
             .setContentTitle(data["title"] as? String ?: "Notification")
             .setContentText(data["body"] as? String ?: "")
             .setSmallIcon(context.applicationInfo.icon)
             .setAutoCancel(true)
-        // Optionally add more fields from data
+            .setContentIntent(pendingIntent)
         notificationManager.notify(System.currentTimeMillis().toInt(), builder.build())
     }
 

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
@@ -123,7 +123,19 @@ class PntaFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, Plugin
     PermissionHandler.cleanup()
   }
 
+  private fun isNotificationTapIntent(intent: Intent): Boolean {
+    val extras = intent.extras ?: return false
+    
+    return extras.containsKey("title") || 
+           extras.containsKey("body") || 
+           extras.containsKey("link_to")
+  }
+
   override fun onNewIntent(intent: Intent): Boolean {
+    if (!isNotificationTapIntent(intent)) {
+      return false
+    }
+    
     val extras = intent.extras
     if (extras != null && !extras.isEmpty) {
       val payload = mutableMapOf<String, Any>()

--- a/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
+++ b/android/src/main/kotlin/io/pnta/pnta_flutter/PntaFlutterPlugin.kt
@@ -126,9 +126,7 @@ class PntaFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware, Plugin
   private fun isNotificationTapIntent(intent: Intent): Boolean {
     val extras = intent.extras ?: return false
     
-    return extras.containsKey("title") || 
-           extras.containsKey("body") || 
-           extras.containsKey("link_to")
+    return !extras.containsKey("com.android.browser.headers")
   }
 
   override fun onNewIntent(intent: Intent): Boolean {

--- a/ios/Classes/ForegroundNotificationHandler.swift
+++ b/ios/Classes/ForegroundNotificationHandler.swift
@@ -32,8 +32,24 @@ class ForegroundNotificationHandler: NSObject, FlutterPlugin, UNUserNotification
     // UNUserNotificationCenterDelegate
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         let userInfo = notification.request.content.userInfo
-        // Forward payload to Dart
-        ForegroundNotificationHandler.eventSink?(userInfo)
+        
+        // Flatten the payload to match Android structure
+        var flattenedData: [String: Any] = [:]
+        
+        // Add all custom data (everything except "aps")
+        for (key, value) in userInfo where key != "aps" {
+            flattenedData[key] = value
+        }
+        
+        // Extract title/body from aps.alert
+        if let aps = userInfo["aps"] as? [String: Any],
+           let alert = aps["alert"] as? [String: Any] {
+            flattenedData["title"] = alert["title"] ?? ""
+            flattenedData["body"] = alert["body"] ?? ""
+        }
+        
+        // Forward flattened payload to Dart
+        ForegroundNotificationHandler.eventSink?(flattenedData)
         // Show or suppress system UI
         if ForegroundNotificationHandler.showSystemUI {
             if #available(iOS 14.0, *) {

--- a/ios/Classes/ForegroundNotificationHandler.swift
+++ b/ios/Classes/ForegroundNotificationHandler.swift
@@ -37,8 +37,10 @@ class ForegroundNotificationHandler: NSObject, FlutterPlugin, UNUserNotification
         var flattenedData: [String: Any] = [:]
         
         // Add all custom data (everything except "aps")
-        for (key, value) in userInfo where key != "aps" {
-            flattenedData[key] = value
+        for (key, value) in userInfo {
+            if let stringKey = key as? String, stringKey != "aps" {
+                flattenedData[stringKey] = value
+            }
         }
         
         // Extract title/body from aps.alert


### PR DESCRIPTION
## Summary
- Remove AGP version constraints for FlutterFlow compatibility
- Fix notification tap double processing from browser header intents
- Make foreground notifications tappable by adding PendingIntent setup
- Standardize iOS foreground payload structure to match Android
- Lower compileSdk to 34 for broader environment support