### PR TITLE
Version 1.1.0 release with Gradle build fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+
+-   Migrate Android Gradle config to plugins { } DSL using Flutter‑recommended approach
+-   Standardize payload schema
+-   Add PendingIntents and filter out non-notification intents
+
 ## 1.0.0
 
 -   Initial stable release of PNTA Flutter plugin.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,10 +1,10 @@
-group = "io.pnta.pnta_flutter"
-version = "1.0.0"
-
 plugins {
     id "com.android.library"
     id "org.jetbrains.kotlin.android"
 }
+
+group = "io.pnta.pnta_flutter"
+version = "1.0.0"
 android {
   
     compileSdkVersion 34

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.pnta.pnta_flutter"
-version = "1.0.0"
+version = "1.1.0"
 android {
   
     compileSdkVersion 34

--- a/ios/pnta_flutter.podspec
+++ b/ios/pnta_flutter.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'pnta_flutter'
-  s.version          = '1.0.0'
+  s.version          = '1.1.0'
   s.summary          = 'Official PNTA Flutter plugin to make push notifications suck less.'
   s.description      = <<-DESC
 A Flutter plugin for requesting push notification permissions and identifying devices on iOS and Android. Integrates with PNTA backend for device registration and metadata collection.

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,3 +1,3 @@
 /// PNTA Flutter SDK version
 /// This should match the version in pubspec.yaml
-const String kPntaSdkVersion = '1.0.0';
+const String kPntaSdkVersion = '1.1.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: pnta_flutter
 description: "Official PNTA Flutter plugin to make push notifications suck less."
-version: 1.0.0
+version: 1.1.0
 homepage: https://pnta.io
 repository: https://github.com/pnta-io/pnta-flutter-plugin
 documentation: https://docs.pnta.io


### PR DESCRIPTION
## Summary
- Fix Gradle build error by reordering plugins block before group/version properties
- Bump version to 1.1.0 across all platform files (pubspec.yaml, build.gradle, podspec, version.dart)
- Add changelog entry documenting recent improvements