### PR TITLE
Simplify URL launcher implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 -   Migrate Android Gradle config to plugins { } DSL using Flutter‑recommended approach
 -   Standardize payload schema
 -   Add PendingIntents and filter out non-notification intents
+-   Simplify URL launcher by removing canLaunchUrl check and Android manifest queries
 
 ## 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -252,25 +252,6 @@ The plugin automatically routes links based on these rules:
 -   **Contains `://`** (e.g., `http://example.com`, `mailto:test@example.com`) → Opens externally via system browser/app
 -   **No `://`** (e.g., `/profile`, `/settings`) → Navigates internally using Flutter's Navigator
 
-### Metadata Best Practices
-
-Store your metadata in one place and use it consistently:
-
-```dart
-class UserMetadata {
-  static Map<String, dynamic> get current => {
-    'user_id': getCurrentUserId(),
-    'app_version': getAppVersion(),
-    'subscription_tier': getSubscriptionTier(),
-    'last_active': DateTime.now().toIso8601String(),
-  };
-}
-
-// Use everywhere
-await PntaFlutter.initialize('prj_XXXXXXXXX', metadata: UserMetadata.current);
-await PntaFlutter.updateMetadata(UserMetadata.current);
-```
-
 ## Example
 
 For a complete working example with all features, see the `example/` app in the plugin repository.

--- a/README.md
+++ b/README.md
@@ -88,30 +88,6 @@ Add at the very bottom:
 apply plugin: 'com.google.gms.google-services'
 ```
 
-#### 3. AndroidManifest.xml Updates (Optional)
-
-**Most configuration is handled automatically by the plugin!** You only need to add the following if your app opens external URLs from notifications:
-
-```xml
-<!-- For opening external URLs (optional - only if your notifications contain links) -->
-<queries>
-  <intent>
-    <action android:name="android.intent.action.VIEW" />
-    <data android:scheme="http" />
-  </intent>
-  <intent>
-    <action android:name="android.intent.action.VIEW" />
-    <data android:scheme="https" />
-  </intent>
-</queries>
-```
-
-**Note:** The plugin automatically handles:
-
--   `POST_NOTIFICATIONS` permission
--   Firebase messaging service registration
--   Default notification channel setup
-
 ## Quick Start Guide
 
 ### 1. One-Line Setup
@@ -209,7 +185,7 @@ PntaFlutter.foregroundNotifications.listen((payload) {
   }
 });
 
-// Remember to cancel subscriptions in dispose() to avoid memory leaks
+
 ```
 
 #### Background/Terminated Notifications
@@ -222,7 +198,7 @@ PntaFlutter.onNotificationTap.listen((payload) {
   // Links are auto-handled if autoHandleLinks is true
 });
 
-// Remember to cancel subscriptions in dispose() to avoid memory leaks
+
 ```
 
 ## API Reference

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,18 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <queries>
-        <intent>
-            <action android:name="android.intent.action.PROCESS_TEXT"/>
-            <data android:mimeType="text/plain"/>
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="http" />
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="https" />
-        </intent>
-    </queries>
     <application
         android:label="pnta_flutter_example"
         android:name="${applicationName}"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -189,7 +189,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.1.0"
   process:
     dependency: transitive
     description:

--- a/lib/src/link_handler.dart
+++ b/lib/src/link_handler.dart
@@ -19,8 +19,8 @@ class LinkHandler {
     }
 
     try {
-      if (link.contains('://')) {
-        final uri = Uri.parse(link);
+      final uri = Uri.parse(link);
+      if (uri.hasScheme) {
         final launched =
             await launchUrl(uri, mode: LaunchMode.externalApplication);
         if (launched) {

--- a/lib/src/link_handler.dart
+++ b/lib/src/link_handler.dart
@@ -21,19 +21,14 @@ class LinkHandler {
     try {
       if (link.contains('://')) {
         final uri = Uri.parse(link);
-        if (await canLaunchUrl(uri)) {
-          final launched =
-              await launchUrl(uri, mode: LaunchMode.externalApplication);
-          if (launched) {
-            debugPrint('PNTA: Successfully launched URL: $link');
-          } else {
-            debugPrint('PNTA: Failed to launch URL: $link');
-          }
-          return launched;
+        final launched =
+            await launchUrl(uri, mode: LaunchMode.externalApplication);
+        if (launched) {
+          debugPrint('PNTA: Successfully launched URL: $link');
         } else {
-          debugPrint('PNTA: Cannot launch URL - no app available: $link');
-          return false;
+          debugPrint('PNTA: Failed to launch URL: $link');
         }
+        return launched;
       } else {
         final navigator = PntaFlutter.navigatorKey.currentState;
         if (navigator != null) {


### PR DESCRIPTION
## Summary
- Remove unnecessary canLaunchUrl check from link handler
- Use uri.hasScheme for cleaner URL vs route detection
- Remove Android manifest queries requirement
- Support mailto:, tel:, sms: schemes automatically